### PR TITLE
Adds an example of how to use 'Arrow'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,13 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.18"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.0"
-    compile 'io.arrow-kt:arrow-core:0.6.1'
-    compile 'io.arrow-kt:arrow-typeclasses:0.6.1'
-    compile 'io.arrow-kt:arrow-data:0.6.1'
-    compile 'io.arrow-kt:arrow-instances:0.6.1'
-    compile 'io.arrow-kt:arrow-syntax:0.6.1'
-    kapt    'io.arrow-kt:arrow-annotations-processor:0.6.1'
+    compile 'io.arrow-kt:arrow-core:0.7.0'
+    compile 'io.arrow-kt:arrow-syntax:0.7.0'
+    compile 'io.arrow-kt:arrow-typeclasses:0.7.0'
+    compile 'io.arrow-kt:arrow-data:0.7.0'
+    compile 'io.arrow-kt:arrow-instances-core:0.7.0'
+    compile 'io.arrow-kt:arrow-instances-data:0.7.0'
+    kapt    'io.arrow-kt:arrow-annotations-processor:0.7.0'
 
     testCompile "io.kotlintest:kotlintest:2.0.5"
     testCompile "org.mockito:mockito-core:2.9.0"

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.18"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.0"
+    compile 'io.arrow-kt:arrow-core:0.6.1'
+    compile 'io.arrow-kt:arrow-typeclasses:0.6.1'
+    compile 'io.arrow-kt:arrow-data:0.6.1'
+    compile 'io.arrow-kt:arrow-instances:0.6.1'
+    compile 'io.arrow-kt:arrow-syntax:0.6.1'
+    kapt    'io.arrow-kt:arrow-annotations-processor:0.6.1'
+
     testCompile "io.kotlintest:kotlintest:2.0.5"
     testCompile "org.mockito:mockito-core:2.9.0"
 }

--- a/readme.md
+++ b/readme.md
@@ -31,3 +31,6 @@
 - [x] mocks / tests
 - [x] JSON / Mappings
 - [x] Java Interoperability
+
+## Functional Programming
+- [x] Validated and Either

--- a/src/main/kotlin/fr/xebia/xke/5_FP.kt
+++ b/src/main/kotlin/fr/xebia/xke/5_FP.kt
@@ -1,0 +1,76 @@
+package fr.xebia.xke
+
+import arrow.core.*
+
+import arrow.core.Either
+import arrow.core.flatMap
+import arrow.data.NonEmptyList
+import arrow.data.Validated
+import arrow.data.applicative
+import arrow.data.ev
+import arrow.syntax.applicative.tupled
+
+/**
+ * This class validates user data in two ways:
+ * - Applicative for all fields (validated all fields)
+ * - Monadic within each field (stops on the first error per field)
+ */
+class UserValidation {
+
+    /*
+     * The following functions might help you
+     * - Option.fromNullable("something")
+     * - Option(maybeRight).toEither { "Left value" }
+     * - Either.cond(true, { 42 }, { "Error" })
+     * - Validated.fromEither(...)
+     * - Validated.applicative<List<String>>()
+            .map2(validated1, validated2, { v: Tuple<Int, Int> -> v.a + v.b })
+            .ev()
+     * - Validated.applicative<NonEmptyList<String>>()
+            .tupled(validated1, validated2, ..., validatedN)
+            .ev()
+            .map{ v: Tuple<Int, Int> -> v.a + v.b }
+     * - NonEmptyList.of("a string", "another string")
+     */
+
+    // TODO find a way to aggregate in an applicative way the 'readName' and 'readAge' functions
+    fun validateUser(params: Map<String, String>): Validated<NonEmptyList<String>, User>  {
+        return Validated.applicative<NonEmptyList<String>>()
+            .tupled(
+                Validated.fromEither(readName(params)),
+                Validated.fromEither(readAge(params)))
+            .ev()
+            .map { z: Tuple2<String, Int> -> User(z.a, z.b) }
+    }
+
+    // TODO read the field 'name' and validate that is non blank
+    fun readName(params: Map<String, String>): Either<NonEmptyList<String>, String> =
+        getValue("name", params)
+            .flatMap { nonBlank ("name", it) }
+
+    // TODO read the field 'age' and validate that is non blank, valid int, and non negative
+    fun readAge(params: Map<String, String>): Either<NonEmptyList<String>, Int> =
+        getValue("age", params)
+            .flatMap { nonBlank ("age", it) }
+            .flatMap { parseInt ("age", it) }
+            .flatMap { nonNegative (it) }
+
+    // TODO get a value from the map or return an error
+    fun getValue(name: String, data: Map<String, String>): Either<NonEmptyList<String>, String> =
+        data[name]?.let { Either.right(it) } ?: Either.left(NonEmptyList.of("$name is not present"))
+
+    fun parseInt(name: String, data: String): Either<NonEmptyList<String>, Int> =
+        try { Either.right(data.toInt()) }
+        catch(e: NumberFormatException) {
+            Either.left(NonEmptyList.of("$name must be an integer"))
+        }
+
+    fun nonBlank(name: String, data: String): Either<NonEmptyList<String>, String> =
+        if (data.isNotEmpty()) Either.right(data)
+        else Either.left(NonEmptyList.of("$name is blank"))
+
+    fun nonNegative(data: Int): Either<NonEmptyList<String>, Int> =
+        if (data > 0) Either.right(data)
+        else Either.left(NonEmptyList.of("$data is negative"))
+
+}

--- a/src/main/kotlin/fr/xebia/xke/5_FP.kt
+++ b/src/main/kotlin/fr/xebia/xke/5_FP.kt
@@ -4,42 +4,39 @@ import arrow.core.*
 
 import arrow.core.Either
 import arrow.core.flatMap
-import arrow.data.NonEmptyList
-import arrow.data.Validated
-import arrow.data.applicative
-import arrow.data.ev
-import arrow.syntax.applicative.tupled
+import arrow.data.*
 
 /**
  * This class validates user data in two ways:
  * - Applicative for all fields (validated all fields)
  * - Monadic within each field (stops on the first error per field)
+ *
+ *
+ * The following functions might help you
+ * - Option.fromNullable("something")
+ * - Option(maybeRight).toEither { "Left value" }
+ * - Try { data.toInt() }.toEither().mapLeft { NonEmptyList.of("$name must be an integer") }
+ * - Either.cond(true, { 42 }, { "Error" })
+ * - Validated.fromEither(...)
+ * - Validated.applicative(NonEmptyList.semigroup<String>())
+ *     .map2(validated1, validated2, { v: Tuple<Int, Int> -> v.a + v.b })
+ *     .fix()
+ * - Validated.applicative(NonEmptyList.semigroup<String>())
+ *    .tupled(validated1, validated2, ..., validatedN)
+ *    .fix()
+ *    .map{ v: Tuple<Int, Int> -> v.a + v.b }
+ * - NonEmptyList.of("a string", "another string")
+ *
  */
 class UserValidation {
 
-    /*
-     * The following functions might help you
-     * - Option.fromNullable("something")
-     * - Option(maybeRight).toEither { "Left value" }
-     * - Either.cond(true, { 42 }, { "Error" })
-     * - Validated.fromEither(...)
-     * - Validated.applicative<List<String>>()
-            .map2(validated1, validated2, { v: Tuple<Int, Int> -> v.a + v.b })
-            .ev()
-     * - Validated.applicative<NonEmptyList<String>>()
-            .tupled(validated1, validated2, ..., validatedN)
-            .ev()
-            .map{ v: Tuple<Int, Int> -> v.a + v.b }
-     * - NonEmptyList.of("a string", "another string")
-     */
-
     // TODO find a way to aggregate in an applicative way the 'readName' and 'readAge' functions
     fun validateUser(params: Map<String, String>): Validated<NonEmptyList<String>, User>  {
-        return Validated.applicative<NonEmptyList<String>>()
+        return Validated.applicative(NonEmptyList.semigroup<String>())
             .tupled(
                 Validated.fromEither(readName(params)),
                 Validated.fromEither(readAge(params)))
-            .ev()
+            .fix()
             .map { z: Tuple2<String, Int> -> User(z.a, z.b) }
     }
 

--- a/src/test/kotlin/fr/xebia/xke/5_FPTest.kt
+++ b/src/test/kotlin/fr/xebia/xke/5_FPTest.kt
@@ -1,10 +1,10 @@
 package fr.xebia.xke
 
 import arrow.data.NonEmptyList
+import arrow.data.invalid
+import arrow.data.valid
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.specs.StringSpec
-
-import arrow.syntax.validated.*
 
 class FP_MockTest : StringSpec({
 

--- a/src/test/kotlin/fr/xebia/xke/5_FPTest.kt
+++ b/src/test/kotlin/fr/xebia/xke/5_FPTest.kt
@@ -1,0 +1,26 @@
+package fr.xebia.xke
+
+import arrow.data.NonEmptyList
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.specs.StringSpec
+
+import arrow.syntax.validated.*
+
+class FP_MockTest : StringSpec({
+
+    mapOf(
+        mapOf("name" to "Terah", "age" to "34") to User("Terah", 34).valid<NonEmptyList<String>, User>(),
+        mapOf("age" to "34") to NonEmptyList.of("name is not present").invalid(),
+        mapOf("name" to "", "age" to "34") to NonEmptyList.of("name is blank").invalid(),
+        mapOf("name" to "Terah") to NonEmptyList.of("age is not present").invalid(),
+        mapOf("name" to "Terah", "age" to "") to NonEmptyList.of("age is blank").invalid(),
+        mapOf("name" to "Terah", "age" to "???") to NonEmptyList.of("age must be an integer").invalid(),
+        mapOf("name" to "Terah", "age" to "-1") to NonEmptyList.of("-1 is negative").invalid(),
+        emptyMap<String, String>() to NonEmptyList.of("name is not present", "age is not present").invalid()
+    ).forEach {
+        "${it.key} should be ${it.value}" {
+            UserValidation().validateUser(it.key). shouldBe (it.value)
+        }
+    }
+
+})


### PR DESCRIPTION
This commit adds an example of data validation using `Arrow` showing the use of:
- Applicatives (Validated)
- Monads (Either)

See https://github.com/arrow-kt/arrow